### PR TITLE
Исправлена отрисовка воллмарков на статичной геометрии

### DIFF
--- a/xray/Layers/xrRender/WallmarksEngine.cpp
+++ b/xray/Layers/xrRender/WallmarksEngine.cpp
@@ -105,6 +105,7 @@ void		CWallmarksEngine::static_wm_render		(CWallmarksEngine::static_wallmark*	W,
 		V->p.set		(el.p);
 		V->color		= C;
 		V->t.set		(el.t);
+		++V;
 	}
 }
 //--------------------------------------------------------------------------------


### PR DESCRIPTION
Предыстория: в одном из прошлых коммитов (e603336d63dd75acf357b7c8acf1a58c1b7ef9a4) в результате рефакторинга был неправильно раскрыт цикл, имеющий отношение к отрисовке воллмарков на геометрии уровня. После этого пропали следы от пуль, кровавые лужи под трупами и, вероятно, некоторые другие важные для игрового процесса мелочи.