### PR TITLE
Исправление многократной коллизии физических объектов

### DIFF
--- a/xray/xrGame/physics_game.cpp
+++ b/xray/xrGame/physics_game.cpp
@@ -220,6 +220,9 @@ void play_particles(float vel_cret, dxGeomUserData* data,  const dContactGeom* c
 	}
 }
 
+// # Hack: limit for sounds and effects
+static u32 lastContactTime = 0;
+
 template<class Pars>
 void  TContactShotMark(CDB::TRI* T,dContactGeom* c)
 {
@@ -268,6 +271,13 @@ void  TContactShotMark(CDB::TRI* T,dContactGeom* c)
 				//ref_shader pWallmarkShader = mtl_pair->CollideMarks[::Random.randI(0,mtl_pair->CollideMarks.size())];
 				Level().ph_commander().add_call(xr_new<CPHOnesCondition>(),xr_new<CPHWallMarksCall>( *((Fvector*)c->pos),T,WallmarkShader));
 			}
+			
+			// # Hack: limit for sounds and effects
+			if (lastContactTime < Device.dwTimeGlobal)
+				return;
+			else
+				lastContactTime = Device.dwTimeGlobal + 500;
+			
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 			if(square_cam_dist<SQUARE_SOUND_EFFECT_DIST)
 			{


### PR DESCRIPTION
Проблема чаще всего проявляется на "деревянных" моделях: планках, столах и т.п. Яркий пример - заколоченный дом на кордоне, при попытке головой снести деревяшки, наблюдается резкое падение FPS, многократное наложение звука удара и неестественное количество партиклов.