### PR TITLE
Возможность принудительно включить EAX на нежелательных аудиокартах

### DIFF
--- a/xray/xrEngine/xr_ioc_cmd.cpp
+++ b/xray/xrEngine/xr_ioc_cmd.cpp
@@ -770,6 +770,7 @@ void CCC_Register()
 	CMD1(CCC_SND_Restart,"snd_restart"			);
 	CMD3(CCC_Mask,		"snd_acceleration",		&psSoundFlags,		ss_Hardware	);
 	CMD3(CCC_Mask,		"snd_efx",				&psSoundFlags,		ss_EAX		);
+	CMD3(CCC_Mask,		"snd_efx_force",		&psSoundFlags,		ss_EAX_FORCE);
 	CMD4(CCC_Integer,	"snd_targets",			&psSoundTargets,	4,32		);
 	CMD4(CCC_Integer,	"snd_cache_size",		&psSoundCacheSizeMB,4,32		);
 

--- a/xray/xrSound/Sound.h
+++ b/xray/xrSound/Sound.h
@@ -46,6 +46,7 @@ XRSOUND_API extern u32				snd_device_id			;
 enum {
 	ss_Hardware			= (1ul<<1ul),	//!< Use hardware mixing only
     ss_EAX				= (1ul<<2ul),	//!< Use eax
+	ss_EAX_FORCE		= (1ul << 3ul),
 	ss_forcedword		= u32(-1)
 };
 

--- a/xray/xrSound/SoundRender_Core.cpp
+++ b/xray/xrSound/SoundRender_Core.cpp
@@ -29,6 +29,7 @@ CSoundRender_Core::CSoundRender_Core	()
 {
 	bPresent					= FALSE;
     bEAX						= FALSE;
+	bUnwantedEAX				= FALSE;
     bDeferredEAX				= FALSE;
 	bUserEnvironment			= FALSE;
 	geom_MODEL					= NULL;
@@ -63,6 +64,9 @@ void CSoundRender_Core::_initialize(int stage)
 {
     Log							("* sound: EAX 2.0 extension:",bEAX?"present":"absent");
     Log							("* sound: EAX 2.0 deferred:",bDeferredEAX?"present":"absent");
+	if (bEAX && bUnwantedEAX)
+		Msg("* EAX 2.0 is present, but unwanted. For enable use command snd_efx_force.");
+
 	Timer.Start					( );
 
     // load environment

--- a/xray/xrSound/SoundRender_Core.h
+++ b/xray/xrSound/SoundRender_Core.h
@@ -25,6 +25,7 @@ public:
 	BOOL								bPresent;
 	BOOL								bUserEnvironment;
     BOOL	 							bEAX;					// Boolean variable to indicate presence of EAX Extension 
+	BOOL								bUnwantedEAX;
     BOOL								bDeferredEAX;
     BOOL								bReady;
 

--- a/xray/xrSound/SoundRender_CoreA.cpp
+++ b/xray/xrSound/SoundRender_CoreA.cpp
@@ -127,7 +127,8 @@ void CSoundRender_CoreA::_initialize(int stage)
     A_CHK				        (alListenerf		(AL_GAIN,1.f));
 
     // Check for EAX extension
-    bEAX 				        = deviceDesc.props.eax && !deviceDesc.props.eax_unwanted;
+	bEAX = deviceDesc.props.eax;
+	bUnwantedEAX = deviceDesc.props.eax_unwanted;
 
     eaxSet 				        = (EAXSet)alGetProcAddress	((const ALchar*)"EAXSet");
     if (eaxSet==NULL) bEAX 		= false;

--- a/xray/xrSound/SoundRender_Core_Processor.cpp
+++ b/xray/xrSound/SoundRender_Core_Processor.cpp
@@ -98,7 +98,7 @@ void CSoundRender_Core::update	( const Fvector& P, const Fvector& D, const Fvect
 	}
 
 	// update EAX
-    if (psSoundFlags.test(ss_EAX) && bEAX)
+	if (psSoundFlags.test(ss_EAX) && bEAX && (!bUnwantedEAX || psSoundFlags.test(ss_EAX_FORCE)))
 	{
         if (bListenerMoved)
 		{


### PR DESCRIPTION
Апдейт EAX-кода на таких аудиокартах чаще всего ложится на и так забитый звуковой поток, поэтому перманентное отключение флага eax_unwanted чревато просадками призводительности. Как вариант - использование дополнительной консольной команды (snd_efx_force), позволяющей принудительно переключить режим работы EAX на нежелательных устройствах. За полезную информацию спасибо @DJYar.