### PR TITLE
Исправлена загрузка теневой геометрии

### DIFF
--- a/xray/Layers/xrRender/FVisual.cpp
+++ b/xray/Layers/xrRender/FVisual.cpp
@@ -92,7 +92,7 @@ void Fvisual::Load		(const char* N, IReader *data, u32 dwFlags)
 			ID							= def().r_u32			();
 			m_fast->iBase				= def().r_u32			();
 			m_fast->iCount				= def().r_u32			();
-			m_fast->dwPrimitives		= iCount/3;
+			m_fast->dwPrimitives		= m_fast->iCount/3;
 		
 			VERIFY						(NULL==m_fast->p_rm_Indices);
 			m_fast->p_rm_Indices		= RImplementation.getIB	(ID,true);


### PR DESCRIPTION
Из-за данной проблемы на некоторых локациях из модов можно было наблюдать баги с фейковыми статическими тенями. Поскольку компилятор локаций мог оптимизировать теневую геометрию так, что удалялись некоторые невалидные треугольники, игра все-равно требовала то количество, что было и у обычной геометрии.